### PR TITLE
Make the recommended config exrm compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ You will need to set the following configuration variables in your
 ```elixir
 use Mix.Config
 
-config :ex_twilio, account_sid: System.get_env("TWILIO_ACCOUNT_SID"),
-                   auth_token:  System.get_env("TWILIO_AUTH_TOKEN")
+config :ex_twilio, account_sid: System.get_env("TWILIO_ACCOUNT_SID") || "${TWILIO_ACCOUNT_SID}",
+                   auth_token:  System.get_env("TWILIO_AUTH_TOKEN") || "${TWILIO_AUTH_TOKEN}"
 ```
 
 For security, I recommend that you use environment variables rather than hard


### PR DESCRIPTION
System variables are embedded in the compiled builds. By leaving the environment blank you can instead rely on EXRM to replace the variables:

References: 

http://engineering.avvo.com/articles/using-env-with-elixir-and-docker.html

http://blog.plataformatec.com.br/2016/05/how-to-config-environment-variables-with-elixir-and-exrm/
